### PR TITLE
ci: automate updating flake inputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,6 @@ jobs:
       image: nixos/nix:latest
       env:
         NIX_EXPERIMENTAL_FEATURES: "nix-command flakes"
-      volumes:
-        - docker_volume:/volume_mount
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/cachix-action@v12
@@ -24,9 +22,9 @@ jobs:
           name: davsanchez
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Build Darwin VM
-        run: nixos-rebuild build --flake .#nixosConfigurations.darwinVM
+        run: nixos-rebuild build --flake .#darwinVM
       - name: Build UTM VM
-        run: nixos-rebuild build .#darwinConfigurations.nr-vm-utm
+        run: nixos-rebuild build --flake .#nr-vm-utm
 
   # TODO: aarch64-darwin is not yet available to run on GitHub Actions
   # test_darwin_builds:
@@ -41,11 +39,11 @@ jobs:
   #         name: davsanchez
   #         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
   #     - name: Install nix-darwin
-  #       run: nix run nix-darwin -- switch --flake .#darwinConfigurations.mbp
+  #       run: nix run nix-darwin -- switch --flake .#mbp
   #     - name: Build Darwin MBP
-  #       run: darwin-rebuild build --flake .#darwinConfigurations.mbp
+  #       run: darwin-rebuild build --flake .#mbp
   #     - name: Build Darwin Mini
-  #       run: darwin-rebuild build --flake .#darwinConfigurations.mini
+  #       run: darwin-rebuild build --flake .#mini
     
   test_home_manager_builds:
     name: Build Home Manager configurations
@@ -68,10 +66,10 @@ jobs:
         run: nix run home-manager/master -- init --switch
       - name: Build Home Manager david@mbp
         if: ${{ matrix.os == 'macos-latest' }}
-        run: home-manager build --flake ".#homeConfigurations.david@mbp"
+        run: home-manager build --flake ".#david@mbp"
       - name: Build Home Manager david@mini
         if: ${{ matrix.os == 'macos-latest' }}
-        run: home-manager build --flake ".#homeConfigurations.david@mini"
+        run: home-manager build --flake ".#david@mini"
       - name: Build Home Manager davidsanchez@nr-vm
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: home-manager build --flake ".#homeConfigurations.davidsanchez@nr-vm"
+        run: home-manager build --flake ".#davidsanchez@nr-vm"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,68 @@
+name: Update flake inputs
+on:
+  schedule:
+    # 1st and 15th of each month at midnight UTC
+    - cron: '0 0 1,15 * *'
+  workflow_dispatch:
+
+jobs:
+
+  update_flake_inputs:
+    name: Update flake inputs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v7
+      - name: Update flake inputs
+        run: nix flake update
+
+  test_nixos_builds:
+    name: Build NixOS configurations
+    runs-on: ubuntu-latest
+    needs: [update_flake_inputs]
+    container:
+      image: nix/nixos:latest
+      env:
+        NIX_EXPERIMENTAL_FEATURES: "nix-command flakes"
+    steps:
+      - name: Build Darwin VM
+        run: nixos-rebuild build --flake .#nixosConfigurations.darwinVM
+      - name: Build UTM VM
+        run: nixos-rebuild build .#darwinConfigurations.nr-vm-utm
+
+  test_darwin_builds:
+    name: Build Darwin configurations
+    runs-on: macos-latest
+    needs: [update_flake_inputs]
+    steps:
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v7
+      - name: Install nix-darwin
+        run: nix run nix-darwin -- switch --flake .#
+      - name: Build Darwin MBP
+        run: darwin-rebuild build --flake .#darwinConfigurations.mbp
+      - name: Build Darwin Mini
+        run: darwin-rebuild build --flake .#darwinConfigurations.mini
+    
+  test_home_manager_builds:
+    name: Build Home Manager configurations
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    needs: [update_flake_inputs]
+    steps:
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v7
+      - name: Install home-manager
+        run: nix run home-manager/master -- init --switch
+      - name: Build Home Manager david@mbp
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: home-manager build --flake ".#homeConfigurations.david@mbp"
+      - name: Build Home Manager david@mini
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: home-manager build --flake ".#homeConfigurations.david@mini"
+      - name: Build Home Manager davidsanchez@nr-vm
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: home-manager build --flake ".#homeConfigurations.davidsanchez@nr-vm"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,26 +1,30 @@
-name: Update flake inputs
+name: Build all Nix configurations
 on:
-  schedule:
-    # 1st and 15th of each month at midnight UTC
-    - cron: '0 0 1,15 * *'
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+  # schedule:
+  #   # 1st and 15th of each month at midnight UTC
+  #   - cron: '0 0 1,15 * *'
   workflow_dispatch:
 
 jobs:
 
-  update_flake_inputs:
-    name: Update flake inputs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v7
-      - name: Update flake inputs
-        run: nix flake update
+  # update_flake_inputs:
+  #   name: Update flake inputs
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Install Nix
+  #       uses: DeterminateSystems/nix-installer-action@v7
+  #     - name: Update flake inputs
+  #       run: nix flake update
 
   test_nixos_builds:
     name: Build NixOS configurations
     runs-on: ubuntu-latest
-    needs: [update_flake_inputs]
+    # needs: [update_flake_inputs]
     container:
       image: nix/nixos:latest
       env:
@@ -34,7 +38,7 @@ jobs:
   test_darwin_builds:
     name: Build Darwin configurations
     runs-on: macos-latest
-    needs: [update_flake_inputs]
+    # needs: [update_flake_inputs]
     steps:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v7
@@ -51,7 +55,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    needs: [update_flake_inputs]
+    # needs: [update_flake_inputs]
     steps:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,10 @@ jobs:
     name: Build Home Manager configurations
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: 
+          - ubuntu-latest
+          # TODO: aarch64-darwin is not yet available to run on GitHub Actions
+          # - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -63,13 +66,12 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Install home-manager
         run: nix run home-manager/master -- init --switch
-      # TODO: aarch64-darwin is not yet available to run on GitHub Actions
-      # - name: Build Home Manager david@mbp
-      #   if: ${{ matrix.os == 'macos-latest' }}
-      #   run: home-manager build --flake ".#homeConfigurations.david@mbp"
-      # - name: Build Home Manager david@mini
-      #   if: ${{ matrix.os == 'macos-latest' }}
-      #   run: home-manager build --flake ".#homeConfigurations.david@mini"
+      - name: Build Home Manager david@mbp
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: home-manager build --flake ".#homeConfigurations.david@mbp"
+      - name: Build Home Manager david@mini
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: home-manager build --flake ".#homeConfigurations.david@mini"
       - name: Build Home Manager davidsanchez@nr-vm
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: home-manager build --flake ".#homeConfigurations.davidsanchez@nr-vm"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,23 +28,24 @@ jobs:
       - name: Build UTM VM
         run: nixos-rebuild build .#darwinConfigurations.nr-vm-utm
 
-  test_darwin_builds:
-    name: Build Darwin configurations
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v7
-      - uses: cachix/cachix-action@v12
-        with:
-          name: davsanchez
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - name: Install nix-darwin
-        run: nix run nix-darwin -- switch --flake .#
-      - name: Build Darwin MBP
-        run: darwin-rebuild build --flake .#darwinConfigurations.mbp
-      - name: Build Darwin Mini
-        run: darwin-rebuild build --flake .#darwinConfigurations.mini
+  # TODO: aarch64-darwin is not yet available to run on GitHub Actions
+  # test_darwin_builds:
+  #   name: Build Darwin configurations
+  #   runs-on: macos-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Install Nix
+  #       uses: DeterminateSystems/nix-installer-action@v7
+  #     - uses: cachix/cachix-action@v12
+  #       with:
+  #         name: davsanchez
+  #         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+  #     - name: Install nix-darwin
+  #       run: nix run nix-darwin -- switch --flake .#darwinConfigurations.mbp
+  #     - name: Build Darwin MBP
+  #       run: darwin-rebuild build --flake .#darwinConfigurations.mbp
+  #     - name: Build Darwin Mini
+  #       run: darwin-rebuild build --flake .#darwinConfigurations.mini
     
   test_home_manager_builds:
     name: Build Home Manager configurations
@@ -62,12 +63,13 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Install home-manager
         run: nix run home-manager/master -- init --switch
-      - name: Build Home Manager david@mbp
-        if: ${{ matrix.os == 'macos-latest' }}
-        run: home-manager build --flake ".#homeConfigurations.david@mbp"
-      - name: Build Home Manager david@mini
-        if: ${{ matrix.os == 'macos-latest' }}
-        run: home-manager build --flake ".#homeConfigurations.david@mini"
+      # TODO: aarch64-darwin is not yet available to run on GitHub Actions
+      # - name: Build Home Manager david@mbp
+      #   if: ${{ matrix.os == 'macos-latest' }}
+      #   run: home-manager build --flake ".#homeConfigurations.david@mbp"
+      # - name: Build Home Manager david@mini
+      #   if: ${{ matrix.os == 'macos-latest' }}
+      #   run: home-manager build --flake ".#homeConfigurations.david@mini"
       - name: Build Home Manager davidsanchez@nr-vm
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: home-manager build --flake ".#homeConfigurations.davidsanchez@nr-vm"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,32 +4,23 @@ on:
     branches: [master]
   push:
     branches: [master]
-  # schedule:
-  #   # 1st and 15th of each month at midnight UTC
-  #   - cron: '0 0 1,15 * *'
   workflow_dispatch:
 
 jobs:
 
-  # update_flake_inputs:
-  #   name: Update flake inputs
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Install Nix
-  #       uses: DeterminateSystems/nix-installer-action@v7
-  #     - name: Update flake inputs
-  #       run: nix flake update
-
   test_nixos_builds:
     name: Build NixOS configurations
     runs-on: ubuntu-latest
-    # needs: [update_flake_inputs]
     container:
-      image: nix/nixos:latest
+      image: nixos/nix:latest
       env:
         NIX_EXPERIMENTAL_FEATURES: "nix-command flakes"
     steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/cachix-action@v12
+        with:
+          name: davsanchez
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Build Darwin VM
         run: nixos-rebuild build --flake .#nixosConfigurations.darwinVM
       - name: Build UTM VM
@@ -38,10 +29,14 @@ jobs:
   test_darwin_builds:
     name: Build Darwin configurations
     runs-on: macos-latest
-    # needs: [update_flake_inputs]
     steps:
+      - uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v7
+      - uses: cachix/cachix-action@v12
+        with:
+          name: davsanchez
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Install nix-darwin
         run: nix run nix-darwin -- switch --flake .#
       - name: Build Darwin MBP
@@ -55,10 +50,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    # needs: [update_flake_inputs]
     steps:
+      - uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v7
+      - uses: cachix/cachix-action@v12
+        with:
+          name: davsanchez
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Install home-manager
         run: nix run home-manager/master -- init --switch
       - name: Build Home Manager david@mbp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,24 +26,23 @@ jobs:
       - name: Build UTM VM
         run: nixos-rebuild build --flake .#nr-vm-utm
 
-  # TODO: aarch64-darwin is not yet available to run on GitHub Actions
-  # test_darwin_builds:
-  #   name: Build Darwin configurations
-  #   runs-on: macos-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Install Nix
-  #       uses: DeterminateSystems/nix-installer-action@v7
-  #     - uses: cachix/cachix-action@v12
-  #       with:
-  #         name: davsanchez
-  #         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-  #     - name: Install nix-darwin
-  #       run: nix run nix-darwin -- switch --flake .#mbp
-  #     - name: Build Darwin MBP
-  #       run: darwin-rebuild build --flake .#mbp
-  #     - name: Build Darwin Mini
-  #       run: darwin-rebuild build --flake .#mini
+  test_darwin_builds:
+    name: Build Darwin configurations
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v7
+      - uses: cachix/cachix-action@v12
+        with:
+          name: davsanchez
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: Install nix-darwin
+        run: nix run nix-darwin -- switch --flake .#mbp
+      - name: Build Darwin MBP
+        run: darwin-rebuild build --flake .#mbp
+      - name: Build Darwin Mini
+        run: darwin-rebuild build --flake .#mini
     
   test_home_manager_builds:
     name: Build Home Manager configurations
@@ -51,8 +50,7 @@ jobs:
       matrix:
         os: 
           - ubuntu-latest
-          # TODO: aarch64-darwin is not yet available to run on GitHub Actions
-          # - macos-latest
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
       image: nixos/nix:latest
       env:
         NIX_EXPERIMENTAL_FEATURES: "nix-command flakes"
+      volumes:
+        - docker_volume:/volume_mount
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/cachix-action@v12

--- a/.github/workflows/update-flake-inputs.yml
+++ b/.github/workflows/update-flake-inputs.yml
@@ -23,8 +23,12 @@ jobs:
       - name: Update flake inputs
         run: nix flake update --commit-lock-file
       - name: Create Pull Request using GH CLI
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr create --title "chore: update flake inputs" --body "Update flake inputs"
       - name: Set branch for auto-merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr merge --squash --auto --delete-branch
       

--- a/.github/workflows/update-flake-inputs.yml
+++ b/.github/workflows/update-flake-inputs.yml
@@ -1,0 +1,30 @@
+name: Update flake inputs
+on:
+  schedule:
+    # 1st and 15th of each month at midnight UTC
+    - cron: '0 0 1,15 * *'
+  workflow_dispatch:
+
+jobs:
+
+  update_flake_inputs:
+    name: Update flake inputs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up git user
+        run: |
+          git config --global user.name 'DavSanchez's GitHub Actions'
+          git config --global user.email 'DavSanchez+automation@users.noreply.github.com
+      - name: Checkout a new branch
+        run: git switch -c chore/update-flake-inputs
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v7
+      - name: Update flake inputs
+        run: nix flake update --commit-lock-file
+      - name: Create Pull Request using GH CLI
+        run: |
+          gh pr create --title "chore: update flake inputs" --body "Update flake inputs"
+      - name: Set branch for auto-merge
+        run: gh pr merge --squash --auto --delete-branch
+      

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699704228,
-        "narHash": "sha256-NApWG385goidsXmsakWgFRjvbH+aw/n1CGGHn/UuXsc=",
+        "lastModified": 1700795494,
+        "narHash": "sha256-gzGLZSiOhf155FW7262kdHo2YDeugp3VuIFb4/GGng0=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "0f1ad801387445fdda01d080db8ecf169be8e793",
+        "rev": "4b9b83d5a92e8c1fbfd8eb27eda375908c11ec4d",
         "type": "github"
       },
       "original": {
@@ -328,11 +328,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1699701045,
-        "narHash": "sha256-mDzUXK7jNO/utInWpSWEX1NgEEunVIpJg+LyPsDTfy0=",
+        "lastModified": 1700559156,
+        "narHash": "sha256-gL4epO/qf+wo30JjC3g+b5Bs8UrpxzkhNBBsUYxpw2g=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "b689465d0c5d88e158e7d76094fca08cc0223aad",
+        "rev": "c3abafb01cd7045dba522af29b625bd1e170c2fb",
         "type": "github"
       },
       "original": {
@@ -348,11 +348,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699783872,
-        "narHash": "sha256-4zTwLT2LL45Nmo6iwKB3ls3hWodVP9DiSWxki/oewWE=",
+        "lastModified": 1700900274,
+        "narHash": "sha256-KWoKDP5I1viHR4bG3ENnJ7H1DD16tXWH4ROvS0IfXw8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "280721186ab75a76537713ec310306f0eba3e407",
+        "rev": "a462e7315deaa8194b0821f726709bb7e51a850c",
         "type": "github"
       },
       "original": {
@@ -563,11 +563,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1699596684,
-        "narHash": "sha256-XSXP8zjBZJBVvpNb2WmY0eW8O2ce+sVyj1T0/iBRIvg=",
+        "lastModified": 1700851152,
+        "narHash": "sha256-3PWITNJZyA3jz5IGREJRfSykM6xSLmD8u5A3WpBCyDM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da4024d0ead5d7820f6bd15147d3fe2a0c0cec73",
+        "rev": "1216a5ba22a93a4a3a3bfdb4bff0f4727c576fcc",
         "type": "github"
       },
       "original": {
@@ -594,11 +594,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1699099776,
-        "narHash": "sha256-X09iKJ27mGsGambGfkKzqvw5esP1L/Rf8H3u3fCqIiU=",
+        "lastModified": 1700794826,
+        "narHash": "sha256-RyJTnTNKhO0yqRpDISk03I/4A67/dp96YRxc86YOPgU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "85f1ba3e51676fa8cc604a3d863d729026a6b8eb",
+        "rev": "5a09cb4b393d58f9ed0d9ca1555016a8543c2ac8",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -328,11 +328,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1700559156,
-        "narHash": "sha256-gL4epO/qf+wo30JjC3g+b5Bs8UrpxzkhNBBsUYxpw2g=",
+        "lastModified": 1701020860,
+        "narHash": "sha256-NwnRn04C8s+hH+KdVtGmVB1FFNIG7DtPJmQSCBDaET4=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "c3abafb01cd7045dba522af29b625bd1e170c2fb",
+        "rev": "b006ec52fce23b1d57f6ab4a42d7400732e9a0a2",
         "type": "github"
       },
       "original": {
@@ -348,11 +348,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700900274,
-        "narHash": "sha256-KWoKDP5I1viHR4bG3ENnJ7H1DD16tXWH4ROvS0IfXw8=",
+        "lastModified": 1701071203,
+        "narHash": "sha256-lQywA7QU/vzTdZ1apI0PfgCWNyQobXUYghVrR5zuIeM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a462e7315deaa8194b0821f726709bb7e51a850c",
+        "rev": "db1878f013b52ba5e4034db7c1b63e8d04173a86",
         "type": "github"
       },
       "original": {
@@ -563,11 +563,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1700851152,
-        "narHash": "sha256-3PWITNJZyA3jz5IGREJRfSykM6xSLmD8u5A3WpBCyDM=",
+        "lastModified": 1700989516,
+        "narHash": "sha256-oKbmPa2wpTHh9XB3+zIx97uMZGNnp97GPliKKG2/plo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1216a5ba22a93a4a3a3bfdb4bff0f4727c576fcc",
+        "rev": "d2e4de209881b38392933fabf303cde3454b0b4c",
         "type": "github"
       },
       "original": {

--- a/home-manager/features/dev/devops.nix
+++ b/home-manager/features/dev/devops.nix
@@ -48,7 +48,8 @@
     ]
     ++ lib.optionals pkgs.stdenv.isDarwin [
       ## Container runtimes on macOS
-      colima
+      colima # Containers
+      tart # VMs
     ];
 
   programs = {

--- a/hosts/darwin/mbp.nix
+++ b/hosts/darwin/mbp.nix
@@ -162,6 +162,7 @@
       "maccy"
       "openemu"
       "openra"
+      "proton-drive"
       "protonmail-bridge"
       "protonvpn"
       "qflipper"

--- a/hosts/darwin/mbp.nix
+++ b/hosts/darwin/mbp.nix
@@ -184,10 +184,7 @@
       "yacreader"
       "zed"
     ];
-    brews = [
-      "ghcup"
-      "tart"
-    ];
+    brews = [];
     masApps = {
       "1Blocker" = 1365531024;
       "Amphetamine" = 937984704;

--- a/hosts/darwin/mini.nix
+++ b/hosts/darwin/mini.nix
@@ -168,6 +168,7 @@
       "openemu"
       "openra"
       "plex-media-server"
+      "proton-drive"
       "protonmail-bridge"
       "protonvpn"
       "qflipper"

--- a/hosts/darwin/mini.nix
+++ b/hosts/darwin/mini.nix
@@ -191,10 +191,7 @@
       "zed"
       "zotero"
     ];
-    brews = [
-      "ghcup"
-      "tart"
-    ];
+    brews = [];
     masApps = {
       "1Blocker" = 1365531024;
       "Amphetamine" = 937984704;

--- a/hosts/darwin/nr.nix
+++ b/hosts/darwin/nr.nix
@@ -164,10 +164,7 @@
       "warp"
       "wireshark"
     ];
-    brews = [
-      "ghcup"
-      "tart" # VMs on Apple Silicon
-    ];
+    brews = [];
     masApps = {
       "1Blocker" = 1365531024;
       "1Password for Safari" = 1569813296;


### PR DESCRIPTION
GitHub Actions does not support `aarch64` runners as of now and absolutely all of my setups are using `aarch64` at the moment, so this will fail every time 🤙👌.

Leaving it here for the ARM future (that will come soon, right...?)!
