### PR TITLE
fix(dips): allow dotnet 6

### DIFF
--- a/hosts/hive/default.nix
+++ b/hosts/hive/default.nix
@@ -18,6 +18,7 @@
         system = "x86_64-linux";
         config.permittedInsecurePackages = [
           "dotnet-sdk-6.0.428"
+          "aspnetcore-runtime-6.0.36"
         ];
       };
     };

--- a/hosts/hive/default.nix
+++ b/hosts/hive/default.nix
@@ -14,7 +14,12 @@
     };
     nodeNixpkgs = {
       foundry-pi = import inputs.nixpkgs { system = "aarch64-linux"; };
-      eter = import inputs.nixpkgs { system = "x86_64-linux"; };
+      eter = import inputs.nixpkgs {
+        system = "x86_64-linux";
+        config.permittedInsecurePackages = [
+          "dotnet-sdk-6.0.428"
+        ];
+      };
     };
   };
   # nixberrypi = ./nixberrypi/configuration.nix;


### PR DESCRIPTION
Revert after https://github.com/NixOS/nixpkgs/issues/360592 and https://github.com/NixOS/nixpkgs/issues/326335 are sorted out.