### PR TITLE
ci: autodiscover configs in build workflows + nixos overlays

### DIFF
--- a/.github/workflows/home-manager.yml
+++ b/.github/workflows/home-manager.yml
@@ -54,7 +54,8 @@ jobs:
                 if $system == "x86_64-linux" then "ubuntu-latest"
                 elif $system == "aarch64-linux" then "ubuntu-24.04-arm"
                 elif $system == "aarch64-darwin" then "macos-latest"
-                else "macos-13" end
+                else error("unsupported system: " + $system)
+                end
               )})' > matrix.json
           echo "matrix=$(cat matrix.json)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/home-manager.yml
+++ b/.github/workflows/home-manager.yml
@@ -90,3 +90,6 @@ jobs:
       - uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+          # build is skipped when no relevant files changed (git-diff gate);
+          # that's a legitimate "nothing to build" state, not a failure.
+          allowed-skips: build

--- a/.github/workflows/home-manager.yml
+++ b/.github/workflows/home-manager.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   discover:
-    runs-on: ubuntu-latest
+    # Home configs are all aarch64-darwin; evaluating them builds the darwin
+    # host pkgs (e.g. catppuccin-build-hook), which can't build on x86_64-linux.
+    runs-on: macos-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       changed: ${{ steps.changed.outputs.changed }}

--- a/.github/workflows/home-manager.yml
+++ b/.github/workflows/home-manager.yml
@@ -1,35 +1,71 @@
 name: Home Manager
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - master
       - renovate/**
-    paths:
-      - 'home/darwin/**'
-      - 'home/modules/**'
-      - 'modules/home/**'
-      - 'lib/**'
-      - 'flake.nix'
-      - 'flake.lock'
-      - '.github/workflows/home-manager.yml'
-  pull_request:
-    paths:
-      - 'home/darwin/**'
-      - 'home/modules/**'
-      - 'modules/home/**'
-      - 'lib/**'
-      - 'flake.nix'
-      - 'flake.lock'
-      - '.github/workflows/home-manager.yml'
 
 jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      changed: ${{ steps.changed.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check for relevant changes
+        id: changed
+        run: |
+          # Manual dispatch always builds.
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PATTERN='^(home|modules/home|lib|pkgs|overlays)/|^flake\.(nix|lock)$'
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="$(git rev-parse HEAD^ 2>/dev/null || echo '')"
+          fi
+          if [ -z "$BASE" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "$BASE" HEAD | grep -Eq "$PATTERN"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Discover Home Manager configs
+        id: matrix
+        run: |
+          nix eval --json '.#homeConfigurations' \
+            --apply 'x: builtins.mapAttrs (n: v: v.pkgs.system) x' \
+          | jq -c 'to_entries | map(
+              .key as $config | .value as $system |
+              { config: $config, system: $system, runner: (
+                if $system == "x86_64-linux" then "ubuntu-latest"
+                elif $system == "aarch64-linux" then "ubuntu-24.04-arm"
+                elif $system == "aarch64-darwin" then "macos-latest"
+                else "macos-13" end
+              )})' > matrix.json
+          echo "matrix=$(cat matrix.json)" >> "$GITHUB_OUTPUT"
+
   build:
-    name: Build Home Manager (${{ matrix.host }})
+    needs: discover
+    if: needs.discover.outputs.changed == 'true'
+    name: Build Home Manager (${{ matrix.config }})
     strategy:
       matrix:
-        host: [solio, sierpe]
-    runs-on: macos-latest
+        include: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
       - name: Free up space
@@ -41,8 +77,8 @@ jobs:
         with:
           name: davsanchez
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build Home Manager (${{ matrix.host }})
-        run: nix run github:nix-community/home-manager/master -- build --keep-going --flake ".#david@${{ matrix.host }}"
+      - name: Build Home Manager (${{ matrix.config }})
+        run: nix run github:nix-community/home-manager/master -- build --keep-going --flake ".#${{ matrix.config }}"
 
   check:
     name: 🟢 Home Manager builds successes required

--- a/.github/workflows/nix-darwin.yml
+++ b/.github/workflows/nix-darwin.yml
@@ -161,3 +161,6 @@ jobs:
       - uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+          # build is skipped when no relevant files changed (git-diff gate);
+          # that's a legitimate "nothing to build" state, not a failure.
+          allowed-skips: build

--- a/.github/workflows/nix-darwin.yml
+++ b/.github/workflows/nix-darwin.yml
@@ -1,35 +1,72 @@
 name: Nix Darwin
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - master
       - renovate/**
-    paths:
-      - 'hosts/darwin/**'
-      - 'modules/darwin/**'
-      - 'lib/**'
-      - 'tests/darwin/**'
-      - 'flake.nix'
-      - 'flake.lock'
-      - '.github/workflows/nix-darwin.yml'
-  pull_request:
-    paths:
-      - 'hosts/darwin/**'
-      - 'modules/darwin/**'
-      - 'lib/**'
-      - 'tests/darwin/**'
-      - 'flake.nix'
-      - 'flake.lock'
-      - '.github/workflows/nix-darwin.yml'
 
 jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      changed: ${{ steps.changed.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check for relevant changes
+        id: changed
+        run: |
+          # Manual dispatch always builds.
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PATTERN='^(hosts/darwin|modules/darwin|modules/home|home|lib|tests/darwin|pkgs|overlays)/|^flake\.(nix|lock)$'
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="$(git rev-parse HEAD^ 2>/dev/null || echo '')"
+          fi
+          if [ -z "$BASE" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "$BASE" HEAD | grep -Eq "$PATTERN"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Discover nix-darwin configs
+        id: matrix
+        run: |
+          # Exclude CI helper configs (linux-builder bootstrap) from the build matrix.
+          nix eval --json '.#darwinConfigurations' \
+            --apply 'x: builtins.mapAttrs (n: v: v.pkgs.system) x' \
+          | jq -c 'to_entries
+              | map(select(.key != "linux-builder-bootstrap"))
+              | map(.key as $host | .value as $system |
+                { host: $host, system: $system, runner: (
+                  if $system == "aarch64-darwin" then "macos-latest"
+                  elif $system == "x86_64-darwin" then "macos-13"
+                  else "ubuntu-latest" end
+                )})' > matrix.json
+          echo "matrix=$(cat matrix.json)" >> "$GITHUB_OUTPUT"
+
   build:
-    name: Build nix-darwin configs (with Linux builder smoke test)
-    runs-on: macos-latest
+    needs: discover
+    if: needs.discover.outputs.changed == 'true'
+    name: Build nix-darwin (${{ matrix.host }})
     strategy:
       matrix:
-        host: [solio, sierpe]
+        include: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
 
@@ -55,7 +92,7 @@ jobs:
           done
 
       # Activate a minimal nix-darwin config that only enables the Linux builder VM.
-      # This bootstrap builder is needed by our real nix-darwin configs (solio/sierpe)
+      # This bootstrap builder is needed by our real nix-darwin configs (solio/sierpe/nr)
       # which configure their own Linux builder with x86_64 emulation support.
       - name: Activate bootstrap Linux builder
         run: >
@@ -82,7 +119,7 @@ jobs:
             echo "Attempt $i failed, waiting 5s for VM to boot..."
             sleep 5
           done
-          
+
           echo "=== Linux builder failed to become responsive after 60s ==="
           echo ""
           echo "=== Launchd service status ==="

--- a/.github/workflows/nix-darwin.yml
+++ b/.github/workflows/nix-darwin.yml
@@ -54,8 +54,8 @@ jobs:
               | map(.key as $host | .value as $system |
                 { host: $host, system: $system, runner: (
                   if $system == "aarch64-darwin" then "macos-latest"
-                  elif $system == "x86_64-darwin" then "macos-13"
-                  else "ubuntu-latest" end
+                  else error("unsupported system for nix-darwin: " + $system)
+                  end
                 )})' > matrix.json
           echo "matrix=$(cat matrix.json)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/nixos.yml
+++ b/.github/workflows/nixos.yml
@@ -54,7 +54,8 @@ jobs:
                 if $system == "x86_64-linux" then "ubuntu-latest"
                 elif $system == "aarch64-linux" then "ubuntu-24.04-arm"
                 elif $system == "aarch64-darwin" then "macos-latest"
-                else "macos-13" end
+                else error("unsupported system: " + $system)
+                end
               )})' > matrix.json
           echo "matrix=$(cat matrix.json)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/nixos.yml
+++ b/.github/workflows/nixos.yml
@@ -90,3 +90,6 @@ jobs:
       - uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+          # build is skipped when no relevant files changed (git-diff gate);
+          # that's a legitimate "nothing to build" state, not a failure.
+          allowed-skips: build

--- a/.github/workflows/nixos.yml
+++ b/.github/workflows/nixos.yml
@@ -1,36 +1,70 @@
 name: NixOS
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - master
       - renovate/**
-    paths:
-      - 'hosts/nixos/**'
-      - 'modules/nixos/**'
-      - 'lib/**'
-      - 'flake.nix'
-      - 'flake.lock'
-      - '.github/workflows/nixos.yml'
-  pull_request:
-    paths:
-      - 'hosts/nixos/**'
-      - 'modules/nixos/**'
-      - 'lib/**'
-      - 'flake.nix'
-      - 'flake.lock'
-      - '.github/workflows/nixos.yml'
 
 jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      changed: ${{ steps.changed.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check for relevant changes
+        id: changed
+        run: |
+          # Manual dispatch always builds.
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PATTERN='^(hosts/nixos|modules/nixos|lib|pkgs|overlays)/|^flake\.(nix|lock)$'
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="$(git rev-parse HEAD^ 2>/dev/null || echo '')"
+          fi
+          if [ -z "$BASE" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "$BASE" HEAD | grep -Eq "$PATTERN"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Discover NixOS configs
+        id: matrix
+        run: |
+          nix eval --json '.#nixosConfigurations' \
+            --apply 'x: builtins.mapAttrs (n: v: v.pkgs.system) x' \
+          | jq -c 'to_entries | map(
+              .key as $host | .value as $system |
+              { host: $host, system: $system, runner: (
+                if $system == "x86_64-linux" then "ubuntu-latest"
+                elif $system == "aarch64-linux" then "ubuntu-24.04-arm"
+                elif $system == "aarch64-darwin" then "macos-latest"
+                else "macos-13" end
+              )})' > matrix.json
+          echo "matrix=$(cat matrix.json)" >> "$GITHUB_OUTPUT"
+
   build:
-    name: Build NixOS config (${{ matrix.host }})
+    needs: discover
+    if: needs.discover.outputs.changed == 'true'
+    name: Build NixOS (${{ matrix.host }} · ${{ matrix.system }})
     strategy:
       matrix:
-        include:
-          - host: eter
-            runner: ubuntu-latest
-          # - host: mora
-          #   runner: ubuntu-24.04-arm
+        include: ${{ fromJSON(needs.discover.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7

--- a/hosts/nixos/modules/nix.nix
+++ b/hosts/nixos/modules/nix.nix
@@ -1,5 +1,14 @@
-_: {
+{ inputs, ... }: {
   nixpkgs.config.allowUnfree = true;
+
+  # Bring our custom packages from the 'pkgs' directory into the NixOS config,
+  # mirroring hosts/darwin/modules/nix.nix and home/modules/nixpkgs.nix so a
+  # package change (pkgs/**) affects the NixOS build too.
+  nixpkgs.overlays = [
+    inputs.self.overlays.additions
+    inputs.self.overlays.stable-packages
+    inputs.self.overlays.modifications
+  ];
 
   nix = {
     settings = {


### PR DESCRIPTION
## Summary

Replaces the hardcoded host matrices in the three build workflows with **nix-eval autodiscovery**, and fixes the auto-merge deadlock by moving path-gating out of `on:` and into a `git diff` step.

### Changes
1. **Autodiscovery** — `discover` job runs `nix eval` on `.#nixosConfigurations`, `.#darwinConfigurations`, `.#homeConfigurations`, maps each config's `system` to a native GitHub runner, and emits a JSON matrix. New hosts appear automatically (e.g. `mora` when uncommented).
2. **Auto-merge fix (nix/git-only, no custom actions)** — removed `on: paths:` (root cause of the `Expected — waiting for status` deadlock) and gate builds inside the workflow with `git diff --name-only`. The required check now *always* runs and reports, so Renovate/dependabot can merge.
3. **NixOS overlays** — added `additions`/`stable-packages`/`modifications` to the NixOS config so a `pkgs/**` change affects it (mirrors darwin/home). Fixed module signature `_:` → `{ inputs, ... }:`.

### What to watch on this PR
- All three workflows should trigger (this PR touches nixos/darwin/home files), and the `changed` gate should report `true`.
- Confirm the discovered matrices render (`eter` for nixos; `sierpe/solio/V9X576T260` for darwin; `david@sierpe/david@solio/davidsanchez@V9X576T260` for home).
- `workflow_dispatch` on each to test the forced-build path.
