### PR TITLE
deps: per-input renovate updates instead of lockfile maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,3 @@ updates:
     directory: /
     schedule:
       interval: weekly
-  - package-ecosystem: nix
-    directory: /
-    schedule:
-      interval: daily

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,13 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "schedule:daily"],
+  "extends": [
+    "config:recommended",
+    "schedule:daily"
+  ],
+  "lockFileMaintenance": {
+    "enabled": false
+  },
   "nix": {
     "enabled": true
   },
   "packageRules": [
     {
       "matchManagers": ["nix"],
-      "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true,
       "automergeType": "branch"
     }


### PR DESCRIPTION
## Summary

Switches nix dependency updates from batched `lockFileMaintenance` to **one PR per flake input**, with auto-merge on green.

### Changes
- `renovate.json`: disable `lockFileMaintenance`, keep `nix.enabled`, add automerge for all nix updates (`automergeType: branch`)
- `dependabot.yml`: drop the `nix` ecosystem (overlaps with renovate); keep `github-actions`

### How it behaves
- **One PR per input** (hermes-agent, home-manager, nixpkgs, darwin, etc.) — each its own branch + commit
- **Auto-merges** when the branch is green
- **Stays open** if the build fails, the commit list for that input can be inspected

### Sequencing note
Renovate reads config from the **default branch**, so it won't generate per-input PRs until this config merges to `master`.