### PR TITLE
ci: always run flake-check required check, gate the heavy check inside

### DIFF
--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -1,22 +1,48 @@
 name: Flake Check
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - master
       - renovate/**
-    paths:
-      - '**.nix'
-      - 'flake.lock'
-      - '.github/workflows/flake-check.yml'
-  pull_request:
-    paths:
-      - '**.nix'
-      - 'flake.lock'
-      - '.github/workflows/flake-check.yml'
 
 jobs:
+  changed:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.diff.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Check for flake-relevant changes
+        id: diff
+        run: |
+          # Manual dispatch always runs the full check.
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PATTERN='\.nix$|^flake\.lock$'
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="$(git rev-parse HEAD^ 2>/dev/null || echo '')"
+          fi
+          if [ -z "$BASE" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "$BASE" HEAD | grep -Eq "$PATTERN"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   flake-check:
+    needs: changed
+    if: needs.changed.outputs.changed == 'true'
     name: nix flake check (${{ matrix.system }})
     strategy:
       matrix:
@@ -63,9 +89,13 @@ jobs:
     name: 🟢 Flake Checks successes required
     if: always()
     needs:
+      - changed
       - flake-check
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+          # flake-check is skipped when no .nix/flake.lock changed; that's a
+          # legitimate "nothing to check" state, not a failure.
+          allowed-skips: flake-check


### PR DESCRIPTION
## Summary

`flake-check.yml` used `on: paths: ['**.nix','flake.lock']`, so PRs touching only other files (e.g. `.github/**`) never triggered it while it was a **required status check** in the `Master branch` ruleset → PRs stayed blocked on "Expected — waiting for status" (e.g. #693).

### Fix
Apply the same **always-trigger + gate-inside** pattern as the build workflows:
- Always run on `pull_request` (required check always reports)
- Run `nix flake check` only when a `.nix` or `flake.lock` file changed
- `check` (alls-green) job passes even when the heavy job is legitimately skipped (`allowed-skips: flake-check`)
- `workflow_dispatch` always runs the full check

### Unblocks
PR #693 (renovate per-input config), which only touches `.github/**`, was blocked on the missing Flake Checks status.
