### PR TITLE
fix: enable renovate nix manager (nix.enabled opt-in)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,9 @@
     "config:recommended",
     "schedule:daily"
   ],
+  "nix": {
+    "enabled": true
+  },
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,


### PR DESCRIPTION
## Summary

**Bug:** Renovate's nix manager was silently disabled, so no `flake.lock` updates happened even with `lockFileMaintenance` enabled.

### Root cause
During the consolidation (#695) I kept `nix` only as `matchManagers: ["nix"]` inside `packageRules`, but **dropped the top-level manager opt-in** `"nix": { "enabled": true }`. Renovate's nix manager is **beta and disabled by default** — the `packageRules` entry only applies *if* the manager runs; it does not enable it. Result: Renovate never scanned `flake.nix`, the dashboard's `nix (1)` section vanished, and manual triggers produced nothing.

### Fix
Add `"nix": { "enabled": true }` at the top level (per Renovate nix-manager docs).

### Expected after merge
- Renovate re-detects `flake.nix` (dashboard `nix` section returns, 11 inputs listed)
- `lockFileMaintenance` starts generating PRs for `flake.lock` on the daily schedule
- Green → auto-merge; red → PR stays open for inspection
