### PR TITLE
fix: switch renovate automergeType to pr

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,18 +10,18 @@
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,
-    "automergeType": "branch"
+    "automergeType": "pr"
   },
   "packageRules": [
     {
       "matchManagers": ["nix"],
       "automerge": true,
-      "automergeType": "branch"
+      "automergeType": "pr"
     },
     {
       "matchManagers": ["github-actions"],
       "automerge": true,
-      "automergeType": "branch"
+      "automergeType": "pr"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Switch Renovate `automergeType` from `branch` to `pr`.

### Why
`automergeType: branch` caused failing lockfile updates to sit **stuck in "Pending Branch Automerge"** with **no PR opened** (the "red → convert to PR" fallback doesn't fire with this repo's strict status-check ruleset). This just happened: the lockfile bump pulled in a nixpkgs rev where `curl-cffi`/`libcurl-impersonate` breaks on macOS → Home Manager failed → the branch stayed pending with no PR.

### With `automergeType: pr`
- Renovate opens a **PR** for each update
- Required checks run **on the PR**
- **Green** → auto-merges (renovate `automerge`)
- **Red** → PR stays **open** for inspection

Green PRs auto-merge and close themselves, so we only ever attend to failing ones.
