### PR TITLE
chore: update nixpkgs-stable flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -294,11 +294,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1786943417,
-        "narHash": "sha256-b4qgjdFtlz5TAZ1Hi7DFJeqX3sjaDUnrwr9OO+O1rM0=",
+        "lastModified": 1787414105,
+        "narHash": "sha256-WncT27+3BOkgTaJZLnCsf3LcYf9RXMuR9ONSN4rzQ7s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0dd31db7e6dbf9ce05697c4545f6fe01accec994",
+        "rev": "a9e6d84f9c2f9012f5fe7d964a7851352300e61a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Update the `nixpkgs-stable` flake input via `nix flake update nixpkgs-stable`.

- `github:nixos/nixpkgs/0dd31db7e6db` (2026-08-17) → `github:nixos/nixpkgs/a9e6d84f9c2f` (2026-08-22)