### PR TITLE
chore: update home-manager flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -198,11 +198,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786999651,
-        "narHash": "sha256-MTGMFlLDTklsXhCp4r5GXB4VAVadPdalXLvUjd/K7h0=",
+        "lastModified": 1787487906,
+        "narHash": "sha256-zIdM+8teujHm5hc5MIPDnV7k2UeOOT/pFyFtWjOCwsY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "353742587cbaf079b3caee743115d037bc51fea6",
+        "rev": "cfba7ad5886b342b8dd63ba74354b3853ea4cfc9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Update the `home-manager` flake input via `nix flake update home-manager`.

- `github:nix-community/home-manager/353742587cba` (2026-08-17) → `github:nix-community/home-manager/cfba7ad5886b` (2026-08-23)