### PR TITLE
chore: update hermes-agent flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -157,11 +157,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1787126215,
-        "narHash": "sha256-QLi0/g8gT5fDhsihWH8Wjk6ilCUWmWNPzqyPgEPcGP4=",
+        "lastModified": 1787513235,
+        "narHash": "sha256-XlQ5y530X484FYkN/gbHEqbq7C4v2E7BwzHSHRkwoDE=",
         "owner": "NousResearch",
         "repo": "hermes-agent",
-        "rev": "63565fa26b00a2096247064785c4380aafab2303",
+        "rev": "6994851694a98c9078bd90f7bc562f7b33f9bb51",
         "type": "github"
       },
       "original": {

--- a/home/modules/ai/hermes-common.nix
+++ b/home/modules/ai/hermes-common.nix
@@ -11,7 +11,10 @@
   sops = {
     defaultSopsFile = ../../../secrets/secrets.yaml;
     age.keyFile = "/Users/david/.config/sops/age/keys.txt";
-    secrets."hermes_env" = { };
+    secrets = {
+      "hermes/env" = { };
+      "hermes/desktop_token" = { };
+    };
   };
 
   # The Hermes CLI on PATH (and HERMES_HOME for shells). This is the
@@ -21,7 +24,7 @@
   programs.hermes-agent.enable = true;
 
   services.hermes-agent = {
-    environmentFiles = [ config.sops.secrets."hermes_env".path ];
+    environmentFiles = [ config.sops.secrets."hermes/env".path ];
 
     settings = {
       model = {

--- a/home/modules/ai/hermes-common.nix
+++ b/home/modules/ai/hermes-common.nix
@@ -14,10 +14,13 @@
     secrets."hermes_env" = { };
   };
 
-  services.hermes-agent = {
-    enable = true;
-    installPackage = true;
+  # The Hermes CLI on PATH (and HERMES_HOME for shells). This is the
+  # "programs" half of the split introduced upstream: `services.hermes-agent`
+  # now only owns the daemon/state/config, and `programs.hermes-agent.enable`
+  # installs the command line. Every host with this module gets the CLI.
+  programs.hermes-agent.enable = true;
 
+  services.hermes-agent = {
     environmentFiles = [ config.sops.secrets."hermes_env".path ];
 
     settings = {

--- a/home/modules/ai/hermes-desktop.nix
+++ b/home/modules/ai/hermes-desktop.nix
@@ -1,13 +1,11 @@
 # The Hermes Electron GUI. Standalone from services.hermes-agent: on a host
 # with no backend/gateway running (see hermes-common.nix), the app spawns its
 # own local backend on demand instead of connecting to a managed one.
+#
+# Since the upstream split, the desktop application is installed through the
+# `programs.hermes-agent.desktop.enable` option (it adds `hermes-desktop` to
+# home.packages, plus a launcher that carries HERMES_HOME and connects to the
+# service's backend when one is configured).
 {
-  inputs,
-  pkgs,
-  ...
-}:
-{
-  home.packages = [
-    inputs.hermes-agent.packages.${pkgs.stdenv.hostPlatform.system}.desktop
-  ];
+  programs.hermes-agent.desktop.enable = true;
 }

--- a/home/modules/ai/hermes-server.nix
+++ b/home/modules/ai/hermes-server.nix
@@ -4,10 +4,17 @@
 # admin panel on the same port) — worth having since host stays 127.0.0.1,
 # so it adds no exposure, just a browser fallback when the desktop app isn't
 # installed/reachable.
+#
+# This module turns ON the `services.hermes-agent` daemon (state, config and
+# the gateway/backend launchd agents). It is imported only by the host that
+# should actually run the service — solio. Hosts that want just the CLI /
+# desktop import `hermes-common.nix` instead, which provides the programs
+# without enabling any daemon.
 {
   imports = [ ./hermes-common.nix ];
 
   services.hermes-agent = {
+    enable = true;
     gateway.enable = true;
     backend = {
       mode = "dashboard";

--- a/home/modules/ai/hermes-server.nix
+++ b/home/modules/ai/hermes-server.nix
@@ -11,6 +11,10 @@
 # desktop import `hermes-common.nix` instead, which provides the programs
 # without enabling any daemon.
 {
+  config,
+  ...
+}:
+{
   imports = [ ./hermes-common.nix ];
 
   services.hermes-agent = {
@@ -20,6 +24,10 @@
       mode = "dashboard";
       host = "127.0.0.1";
       port = 9119;
+      # Let Hermes Desktop connect to this backend instead of starting a
+      # second one. The token is a sops runtime path (never a Nix store
+      # path), so only the owning user can read it.
+      sessionTokenFile = config.sops.secrets."hermes/desktop_token".path;
     };
   };
 }

--- a/secrets/secrets.yaml
+++ b/secrets/secrets.yaml
@@ -1,8 +1,10 @@
-zfs_mail_pass: ENC[AES256_GCM,data:s3ywrPsvGEa0l+9y8zDBzaE=,iv:tBYBjxNouXN7lkuQIrs1L42HZ6ueBOM+HGjcU8ME/fg=,tag:Q+pnt6ttuc1Yu70YJWz/FA==,type:str]
+zfs_mail_pass: ENC[AES256_GCM,data:yB0pgjhyVN/YM+WKAOPrSw==,iv:gCXqdDTNUrINCB45RVZSwT9GzVUTOQ91wbC1b3mB5Gk=,tag:oZtO5Qoy49us+hP6csMRPQ==,type:str]
 gandi_pat: ENC[AES256_GCM,data:eAnIhNJ70dYpBrwoSxzq+Yk9fNOs0HVEdOGWBWJoBAB6G4WB2ryh0yk99rdWMSddIsDTf9+c3ce+UO7kXtTgjJUHXM+OCrI=,iv:W5kFtSD/dGRBmG3Rejgs2lQFJn9PM3zeAauxtc6rqDs=,tag:L64YsaLdyX6zzHBA0nJXmQ==,type:str]
-lidarr_api_key: ENC[AES256_GCM,data:viNBfakNlmP1QEB+3276m3ibyobMaZKNiB39EzcrgjN1,iv:Z7+WfcDzcOM0lLnTjJ6VwtKq6kybTr0eT8RG3JQlayI=,tag:8HPGSkyQh9NNX5j4RYpO6Q==,type:str]
+lidarr_api_key: ENC[AES256_GCM,data:Mxl/lhfmr8bLemqVOgBBzOrYYCKgCGTonWgYU+oAirs=,iv:W4UTw4MWt3TCsMlW5Xi7sOHi1JpG0BUZcBK7rv+vIoI=,tag:bTR6C9SX8P3k6VwfxO9ibA==,type:str]
 dome_wifi: ENC[AES256_GCM,data:ut5qD4hBAfWRPq0XoocO3Yz9aw6WxKnVXVuT3TAKmPqWVmGe1K9xGEA=,iv:gntdimeKvM+fCfzTtdZSwDmjG8odVA/xrKNoHY6O88M=,tag:o9eaEnMaAxg4D5euYWe/sw==,type:str]
-hermes_env: ENC[AES256_GCM,data:syrKA7bKJf/FMikwjxN75IntnC8dRC5CURzNGcYl/5DDI0BhJbV//pebv5Fwg3sM2S+0qqCj0AvNZT9myJi4IJbmc3IHEUjvHrf/WM7r1DpZM3RZg0YGIPU3eSTWD6p+T5jX8Z1XAzP5xV9HFDZRDx7JwOeESbExVqkYktDchESJCz/3NXOJZnOPntZ+LKXRqQIz+0a/PyJkYcAUZ6D90+TDNV5bCl8dwmasnabfqQy0HeugeNN1bdHYC6pCLGug4wfBjUbY2T+WWG1bAII//suRiGfEQwO8rPpUS1NYxau4z8RC4bgEuIGZGs3jQSVhxgAF90jPYji9C6H5Xg26Gtg5uiPo65r7xgZLMwRAf58hrNhauztU1h2lWF1eeVyZ1KWxT9JI1a9oDo7h/4QrGvT6v5PGqH9l4nU=,iv:h9vNbV4/zZdrCXbaX4XEUmsY+dwpKkKli+uQ7AcXgSQ=,tag:t28jiP2n0Ii5zTEUuimQTg==,type:str]
+hermes:
+    desktop_token: ENC[AES256_GCM,data:NtwWvNTgf582RNnn7yPW6Q==,iv:IS/fWOv9iQUmZmK6vmcfw/mIMuKalTPRG+zm86kof3g=,tag:LXx58sR3YTGIvTrBR/0jZQ==,type:str]
+    env: ENC[AES256_GCM,data:lPw6fKAbU4JCR992WXEEtX0pL/+M1BhJ5mPYvyA0PYIQKt7w4xe0qd8Siy1vF+O9dpGUnf6nhmC/xfuWY8iH9G6eWDGARaszOFDbfC19qMsLX3/FkPliQ5McKXtvaVoANMAQD+cSZDBhfwYKXYwJoGAtecb5uSnteUTYGRC//Ii5GhT15b3+D26RKCDbPyQg/Q9qRtGC26rruRqqqc6cMfccdl4dBUWoG5mCrVg2rVfW6sUmLxKrI+Fe7v2PVAHSeLvl9Cm+Om6ZOSCMpsCI4mNswyXOS7hc2H6OArQ2vaKtPG+OPeKPx47UBq+ITXwwhP0MDtzOH6Mmdfqm6wfI+grXclzERsM4ts9T00wWXaIwvFNN7mqqqTItjN1biMrZZwt9o+rKiidNbnZ+uxvnTb1t06q9QPVfumc=,iv:X2MNamZHYPuVJZAPrGMwXSKWVAd09v14lJmVOB49PVA=,tag:fSKMCtGkdH0VNXCHmn0eVQ==,type:str]
 sops:
     age:
         - enc: |
@@ -41,7 +43,7 @@ sops:
             6YMZqEqhc8xRC/j8KEfGjSQdokYjZbg7Gtm4s5+WM5famyJlHs2viQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1thxs2h3lxq08rm5yczm4q2cf9cpgug3esfv5lwly9d7m0rj7lacq3nq5kg
-    lastmodified: "2026-08-19T09:43:37Z"
-    mac: ENC[AES256_GCM,data:LDR1INuD0OQCbCNbs28AlT2bMDbhDtb+tgeGhfmKikXEf6yCRbuwIfGQ5ciHe96pFo44yJyfqOi2WLYBEJGzy1myJQOpwWcK6YPyYV/XdLXN7iOco15q06WtQ+bxELdnLh3udzEszkI3gfe0ErsTYuaDhAUrgutY0W3Qz6xS/z0=,iv:5yZ6oHoX9JHmVQ/E2WYSSwIddOEfKOZuSlr1RR5hb9k=,tag:SV21iYzCcPwHrjRoO+LdZA==,type:str]
+    lastmodified: "2026-08-23T20:07:40Z"
+    mac: ENC[AES256_GCM,data:VWpJleCEr1Bldas+IsTcmG8MlyC7Fx56i92FZAsSn0yyU98Mao1yde8Txmj3lmTnPieKjeGN5O9vWptoU3fafA0Eul5swvwN+E6rCPzfhlk5BKVI6hPLJueZt+2yxWU0fyp7/gaxpbHg+XTG4qOtj65RyKbRmt3ZvEAhiR0kjOA=,iv:6ZHG3p1Tws2O0Bq9kqyIOWnL+qFr7TNmp3OD59kUJPc=,tag:GNlnMladrvhXUjl2LSgoZQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
Update the `hermes-agent` flake input via `nix flake update hermes-agent`.

- `github:NousResearch/hermes-agent/63565fa26b00` (2026-08-19) → `github:NousResearch/hermes-agent/6994851694a9` (2026-08-23)