### PR TITLE
fix: fail discover step loudly on nix eval error

### DIFF
--- a/.github/workflows/home-manager.yml
+++ b/.github/workflows/home-manager.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Discover Home Manager configs
         id: matrix
         run: |
+          set -euo pipefail
           nix eval --json '.#homeConfigurations' \
             --apply 'x: builtins.mapAttrs (n: v: v.pkgs.system) x' \
           | jq -c 'to_entries | map(
@@ -58,6 +59,7 @@ jobs:
                 else error("unsupported system: " + $system)
                 end
               )})' > matrix.json
+          [ -s matrix.json ] || { echo "matrix is empty — nix eval failed" >&2; exit 1; }
           echo "matrix=$(cat matrix.json)" >> "$GITHUB_OUTPUT"
 
   build:

--- a/.github/workflows/nix-darwin.yml
+++ b/.github/workflows/nix-darwin.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Discover nix-darwin configs
         id: matrix
         run: |
+          set -euo pipefail
           # Exclude CI helper configs (linux-builder bootstrap) from the build matrix.
           nix eval --json '.#darwinConfigurations' \
             --apply 'x: builtins.mapAttrs (n: v: v.pkgs.system) x' \
@@ -56,6 +57,7 @@ jobs:
                   else error("unsupported system for nix-darwin: " + $system)
                   end
                 )})' > matrix.json
+          [ -s matrix.json ] || { echo "matrix is empty — nix eval failed" >&2; exit 1; }
           echo "matrix=$(cat matrix.json)" >> "$GITHUB_OUTPUT"
 
   build:

--- a/.github/workflows/nixos.yml
+++ b/.github/workflows/nixos.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Discover NixOS configs
         id: matrix
         run: |
+          set -euo pipefail
           nix eval --json '.#nixosConfigurations' \
             --apply 'x: builtins.mapAttrs (n: v: v.pkgs.system) x' \
           | jq -c 'to_entries | map(
@@ -56,6 +57,7 @@ jobs:
                 else error("unsupported system: " + $system)
                 end
               )})' > matrix.json
+          [ -s matrix.json ] || { echo "matrix is empty — nix eval failed" >&2; exit 1; }
           echo "matrix=$(cat matrix.json)" >> "$GITHUB_OUTPUT"
 
   build:


### PR DESCRIPTION
## Summary

Fix the `discover` step so a `nix eval` failure fails loudly instead of producing a confusing downstream "build failure."

### The bug (seen on PR #702)
The discover step ran:
```bash
nix eval --json '.#homeConfigurations' --apply '...' | jq -c '...' > matrix.json
echo "matrix=$(cat matrix.json)" >> "$GITHUB_OUTPUT"
```
In bash, a pipeline's exit code is the **last** command's (`jq`), not `nix eval`'s. When `nix eval` failed (the hermes-agent `services.hermes-agent.installPackage was removed` assertion on #702):
- The eval error went to stderr, producing no JSON on stdout
- `jq` produced an **empty** `matrix.json`
- The step was marked **success** (jq exit 0)
- `GITHUB_OUTPUT` got an **empty matrix**
- The `build` job then failed at `fromJSON("")` → confusing "build failed" instead of the real eval error

### Fix
- Add `set -euo pipefail` so a `nix eval` failure propagates and fails the step loudly
- Guard `[ -s matrix.json ]` so an empty matrix fails explicitly with the actual error

Applied to the discover step in `nixos.yml`, `home-manager.yml`, `nix-darwin.yml`.

Verified locally: a failing eval now exits non-zero with the real message; the happy path still produces the correct matrix.
