### PR TITLE
chore: tidy hermes modules (trim comments, scope desktop_token to solio)

### DIFF
--- a/home/modules/ai/hermes-common.nix
+++ b/home/modules/ai/hermes-common.nix
@@ -17,10 +17,6 @@
     };
   };
 
-  # The Hermes CLI on PATH (and HERMES_HOME for shells). This is the
-  # "programs" half of the split introduced upstream: `services.hermes-agent`
-  # now only owns the daemon/state/config, and `programs.hermes-agent.enable`
-  # installs the command line. Every host with this module gets the CLI.
   programs.hermes-agent.enable = true;
 
   services.hermes-agent = {

--- a/home/modules/ai/hermes-common.nix
+++ b/home/modules/ai/hermes-common.nix
@@ -11,10 +11,7 @@
   sops = {
     defaultSopsFile = ../../../secrets/secrets.yaml;
     age.keyFile = "/Users/david/.config/sops/age/keys.txt";
-    secrets = {
-      "hermes/env" = { };
-      "hermes/desktop_token" = { };
-    };
+    secrets."hermes/env" = { };
   };
 
   programs.hermes-agent.enable = true;

--- a/home/modules/ai/hermes-common.nix
+++ b/home/modules/ai/hermes-common.nix
@@ -19,6 +19,7 @@
 
   programs.hermes-agent.enable = true;
 
+  # Config only — the service itself is enabled by hermes-server.nix (solio).
   services.hermes-agent = {
     environmentFiles = [ config.sops.secrets."hermes/env".path ];
 

--- a/home/modules/ai/hermes-desktop.nix
+++ b/home/modules/ai/hermes-desktop.nix
@@ -1,11 +1,6 @@
 # The Hermes Electron GUI. Standalone from services.hermes-agent: on a host
 # with no backend/gateway running (see hermes-common.nix), the app spawns its
 # own local backend on demand instead of connecting to a managed one.
-#
-# Since the upstream split, the desktop application is installed through the
-# `programs.hermes-agent.desktop.enable` option (it adds `hermes-desktop` to
-# home.packages, plus a launcher that carries HERMES_HOME and connects to the
-# service's backend when one is configured).
 {
   programs.hermes-agent.desktop.enable = true;
 }

--- a/home/modules/ai/hermes-server.nix
+++ b/home/modules/ai/hermes-server.nix
@@ -11,6 +11,8 @@
 {
   imports = [ ./hermes-common.nix ];
 
+  sops.secrets."hermes/desktop_token" = { };
+
   services.hermes-agent = {
     enable = true;
     gateway.enable = true;

--- a/home/modules/ai/hermes-server.nix
+++ b/home/modules/ai/hermes-server.nix
@@ -4,12 +4,6 @@
 # admin panel on the same port) — worth having since host stays 127.0.0.1,
 # so it adds no exposure, just a browser fallback when the desktop app isn't
 # installed/reachable.
-#
-# This module turns ON the `services.hermes-agent` daemon (state, config and
-# the gateway/backend launchd agents). It is imported only by the host that
-# should actually run the service — solio. Hosts that want just the CLI /
-# desktop import `hermes-common.nix` instead, which provides the programs
-# without enabling any daemon.
 {
   config,
   ...
@@ -24,9 +18,6 @@
       mode = "dashboard";
       host = "127.0.0.1";
       port = 9119;
-      # Let Hermes Desktop connect to this backend instead of starting a
-      # second one. The token is a sops runtime path (never a Nix store
-      # path), so only the owning user can read it.
       sessionTokenFile = config.sops.secrets."hermes/desktop_token".path;
     };
   };


### PR DESCRIPTION
Tidies the hermes-agent modules after the programs/services migration (PR #702).

**Trims redundant comments:**
- `hermes-common.nix`: drop the 4-line explanation before `programs.hermes-agent.enable`
- `hermes-desktop.nix`: drop the 5-line upstream-split note
- `hermes-server.nix`: drop the 6-line module-purpose block and 3-line `sessionTokenFile` comment

**Scopes the `hermes/desktop_token` secret to solio:**
- It was declared in `hermes-common.nix` (shared by solio + sierpe) but only consumed by the solio service via `backend.sessionTokenFile`.
- Moved the declaration into `hermes-server.nix` (solio-only), so sierpe no longer materializes an unused secret. sierpe keeps only `hermes/env`.

Comments and secret scoping only; no behavior change. hermes remains on solio (programs + service + desktop) and sierpe (programs + desktop only).