### PR TITLE
feat: switch default shell to nushell

### DIFF
--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -1,4 +1,9 @@
-{ pkgs, ... }:
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
 {
   services.ollama.enable = true;
 
@@ -18,6 +23,11 @@
         ui = {
           sound.enabled = true;
           toast.delivery = "system";
+        };
+      }
+      // lib.optionalAttrs config.programs.nushell.enable {
+        terminal = {
+          default_shell = "nu";
         };
       };
     };

--- a/home/modules/nu.nix
+++ b/home/modules/nu.nix
@@ -28,8 +28,103 @@
     # extraEnv = ...;
     # extraLogin = ...;
 
+    shellAliases = {
+      # fish's gitignore function, ported
+      gitignore = "curl -sL https://www.gitignore.io/api";
+    };
+
     settings = {
       highlight_resolved_externals = true;
+      show_banner = false;
+      # Helix-style selection-first editing (nushell 0.115+)
+      edit_mode = "helix";
+      buffer_editor = "hx";
+      cursor_shape = {
+        helix_normal = "block";
+        helix_select = "block";
+        helix_insert = "line";
+      };
+      # OSC 133 for ghostty shell integration (cwd + command marks)
+      shell_integration = {
+        osc133 = true;
+      };
+      # Fish-style abbreviations (nushell 0.113+), expanded on space/enter
+      abbreviations = {
+        # ls family (mirrors the fish aliases; `eza` itself is aliased by home-manager)
+        ls = "eza";
+        la = "eza -a";
+        ll = "eza -l";
+        lla = "eza -la";
+        lt = "eza --tree";
+
+        # git (curated from fish's plugin-git; `gcm` intentionally differs from
+        # nu_scripts' alias so it matches fish's `git commit -m`)
+        g = "git";
+        ga = "git add";
+        gaa = "git add --all";
+        gau = "git add --update";
+        gapa = "git add --patch";
+        gb = "git branch";
+        gba = "git branch --all";
+        gbl = "git blame -b -w";
+        gbd = "git branch -d";
+        gco = "git checkout";
+        gcb = "git checkout -b";
+        gc = "git commit --verbose";
+        gca = "git commit --verbose --all";
+        gcm = "git commit -m";
+        gcam = "git commit --all -m";
+        gcl = "git clone";
+        gclean = "git clean -di";
+        gcp = "git cherry-pick";
+        gd = "git diff";
+        gdca = "git diff --cached";
+        gds = "git diff --stat";
+        gdt = "git diff-tree --no-commit-id --name-only -r";
+        gf = "git fetch";
+        gfa = "git fetch --all --prune";
+        gfo = "git fetch origin";
+        gl = "git pull";
+        gll = "git pull origin";
+        glr = "git pull --rebase";
+        glo = "git log --oneline --decorate --color";
+        glg = "git log --stat";
+        glgg = "git log --graph";
+        gm = "git merge";
+        gma = "git merge --abort";
+        gp = "git push";
+        gpo = "git push origin";
+        gpu = "git push origin (git branch --show-current) --set-upstream";
+        gr = "git remote --verbose";
+        gra = "git remote add";
+        grb = "git rebase";
+        grba = "git rebase --abort";
+        grbc = "git rebase --continue";
+        grbi = "git rebase --interactive";
+        grbs = "git rebase --skip";
+        grev = "git revert";
+        grh = "git reset";
+        grhh = "git reset --hard";
+        grm = "git rm";
+        grs = "git restore";
+        grst = "git restore --staged";
+        gsh = "git show";
+        gsb = "git status --short --branch";
+        gss = "git status --short";
+        gst = "git status";
+        gsta = "git stash push";
+        gstaa = "git stash apply";
+        gstd = "git stash drop";
+        gstl = "git stash list";
+        gstp = "git stash pop";
+        gsw = "git switch";
+        gswc = "git switch --create";
+        gignore = "git update-index --assume-unchanged";
+        gunignore = "git update-index --no-assume-unchanged";
+        gup = "git pull --rebase";
+        gwt = "git worktree";
+        gwta = "git worktree add";
+      };
     };
 
     plugins =

--- a/home/modules/terminals/ghostty/default.nix
+++ b/home/modules/terminals/ghostty/default.nix
@@ -62,8 +62,8 @@
       # ];
       macos-option-as-alt = "left";
     }
-    // lib.optionalAttrs config.programs.fish.enable {
-      command = lib.getExe config.programs.fish.package;
+    // lib.optionalAttrs config.programs.nushell.enable {
+      command = lib.getExe config.programs.nushell.package;
     };
   }
   // lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {

--- a/home/modules/vscode/settings.nix
+++ b/home/modules/vscode/settings.nix
@@ -1,4 +1,9 @@
-{ pkgs, ... }:
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
 {
   programs.vscode.profiles.default.userSettings = {
     "breadcrumbs.enabled" = true;
@@ -46,14 +51,14 @@
       "**/.direnv" = true;
     };
     "terminal.external.osxExec" = "Ghostty.app";
-    "terminal.integrated.defaultProfile.linux" = "nu";
-    "terminal.integrated.defaultProfile.osx" = "nu";
-    "terminal.integrated.profiles.linux" = {
+    "terminal.integrated.defaultProfile.linux" = lib.mkIf config.programs.nushell.enable "nu";
+    "terminal.integrated.defaultProfile.osx" = lib.mkIf config.programs.nushell.enable "nu";
+    "terminal.integrated.profiles.linux" = lib.mkIf config.programs.nushell.enable {
       "nu" = {
         path = "nu";
       };
     };
-    "terminal.integrated.profiles.osx" = {
+    "terminal.integrated.profiles.osx" = lib.mkIf config.programs.nushell.enable {
       "nu" = {
         path = "nu";
       };

--- a/home/modules/vscode/settings.nix
+++ b/home/modules/vscode/settings.nix
@@ -46,8 +46,18 @@
       "**/.direnv" = true;
     };
     "terminal.external.osxExec" = "Ghostty.app";
-    "terminal.integrated.defaultProfile.linux" = "fish";
-    "terminal.integrated.defaultProfile.osx" = "fish";
+    "terminal.integrated.defaultProfile.linux" = "nu";
+    "terminal.integrated.defaultProfile.osx" = "nu";
+    "terminal.integrated.profiles.linux" = {
+      "nu" = {
+        path = "nu";
+      };
+    };
+    "terminal.integrated.profiles.osx" = {
+      "nu" = {
+        path = "nu";
+      };
+    };
     "terminal.integrated.fontFamily" =
       "'Iosevka Term Slab', FiraCode, Menlo, Monaco, 'Courier New', monospace";
     "terminal.integrated.fontSize" = 14;

--- a/home/modules/vscode/settings.nix
+++ b/home/modules/vscode/settings.nix
@@ -51,18 +51,6 @@
       "**/.direnv" = true;
     };
     "terminal.external.osxExec" = "Ghostty.app";
-    "terminal.integrated.defaultProfile.linux" = lib.mkIf config.programs.nushell.enable "nu";
-    "terminal.integrated.defaultProfile.osx" = lib.mkIf config.programs.nushell.enable "nu";
-    "terminal.integrated.profiles.linux" = lib.mkIf config.programs.nushell.enable {
-      "nu" = {
-        path = "nu";
-      };
-    };
-    "terminal.integrated.profiles.osx" = lib.mkIf config.programs.nushell.enable {
-      "nu" = {
-        path = "nu";
-      };
-    };
     "terminal.integrated.fontFamily" =
       "'Iosevka Term Slab', FiraCode, Menlo, Monaco, 'Courier New', monospace";
     "terminal.integrated.fontSize" = 14;
@@ -99,5 +87,19 @@
       };
     };
     "acp.defaultProvider" = "hermes";
+  }
+  // lib.optionalAttrs config.programs.nushell.enable {
+    "terminal.integrated.defaultProfile.linux" = "nu";
+    "terminal.integrated.defaultProfile.osx" = "nu";
+    "terminal.integrated.profiles.linux" = {
+      "nu" = {
+        path = "nu";
+      };
+    };
+    "terminal.integrated.profiles.osx" = {
+      "nu" = {
+        path = "nu";
+      };
+    };
   };
 }

--- a/home/modules/zed.nix
+++ b/home/modules/zed.nix
@@ -38,12 +38,13 @@
           "Courier New"
         ];
         max_scroll_history_lines = 5000;
-
-        shell = lib.mkIf config.programs.nushell.enable {
-          program = lib.getExe config.programs.nushell.package;
-        };
         # scroll_multiplier = 3.0;
         # option_as_meta = true; # `true` prevents writing `#` on term as it applies to both sides
+      }
+      // lib.optionalAttrs config.programs.nushell.enable {
+        shell = {
+          program = lib.getExe config.programs.nushell.package;
+        };
       };
       git = {
         inline_blame = {

--- a/home/modules/zed.nix
+++ b/home/modules/zed.nix
@@ -39,7 +39,7 @@
         ];
         max_scroll_history_lines = 5000;
 
-        shell = {
+        shell = lib.mkIf config.programs.nushell.enable {
           program = lib.getExe config.programs.nushell.package;
         };
         # scroll_multiplier = 3.0;

--- a/home/modules/zed.nix
+++ b/home/modules/zed.nix
@@ -1,4 +1,9 @@
-{ pkgs, lib, ... }:
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
 {
   programs.zed-editor = {
     enable = true;
@@ -35,7 +40,7 @@
         max_scroll_history_lines = 5000;
 
         shell = {
-          program = "${lib.getExe pkgs.fish}";
+          program = lib.getExe config.programs.nushell.package;
         };
         # scroll_multiplier = 3.0;
         # option_as_meta = true; # `true` prevents writing `#` on term as it applies to both sides

--- a/home/modules/zellij/default.nix
+++ b/home/modules/zellij/default.nix
@@ -6,9 +6,9 @@
     settings = {
       ui.pane_frames.rounded_corners = true;
     }
-    # Let's use fish as the default shell (if enabled)
-    // lib.optionalString config.programs.fish.enable {
-      default_shell = "${config.programs.fish.package}/bin/fish";
+    # Let's use nushell as the default shell (if enabled)
+    // lib.optionalAttrs config.programs.nushell.enable {
+      default_shell = "${config.programs.nushell.package}/bin/nu";
     };
   };
 

--- a/home/modules/zellij/default.nix
+++ b/home/modules/zellij/default.nix
@@ -8,7 +8,7 @@
     }
     # Let's use nushell as the default shell (if enabled)
     // lib.optionalAttrs config.programs.nushell.enable {
-      default_shell = "${config.programs.nushell.package}/bin/nu";
+      default_shell = lib.getExe config.programs.nushell.package;
     };
   };
 


### PR DESCRIPTION
## Summary
Switch the interactive default shell from fish to nushell across the configured terminals, and add nushell goodies.

## Changes
- **`home/modules/nu.nix`**
  - Enable **helix edit mode** (`edit_mode = "helix"`) with helix cursor shapes (nushell 0.115+)
  - Add **fish-style abbreviations** via `settings.abbreviations` (nushell 0.113+): ls-family (`ls/la/ll/lla/lt`) + curated git set from fish's plugin-git
  - `gcm` intentionally maps to `git commit -m` (matches fish), overriding nu_scripts' checkout-main alias
  - Goodies: `show_banner = false`, `buffer_editor = "hx"`, `shell_integration.osc133 = true` (ghostty cwd/command marks)
  - Port fish `gitignore` function as a `shellAlias`
- **Shell role switches** (apps only; macOS login shell + fish module untouched):
  - ghostty `command` → nushell
  - zellij `default_shell` → nushell
  - vscode terminal defaultProfile (osx/linux) → `nu`
  - zed terminal `shell.program` → nushell

## Notes
- Abbreviations use the existing `programs.nushell.settings.abbreviations` (flattens to `$env.config.abbreviations.*`); the dedicated upstream home-manager option was reverted as redundant (nix-community/home-manager#9433 → #9442).
- Validated with `nix eval` of the generated config and `nix build --dry-run` for `david@solio` and `david@sierpe`.